### PR TITLE
[typeChecker] type check 시 lodash library 대신 native code 사용

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "axios": "^0.21.1",
     "http-status-codes": "^2.1.4",
-    "lodash": "^4.17.21",
     "next": "latest",
     "primeflex": "^2.0.0",
     "primeicons": "^4.1.0",
@@ -31,7 +30,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/lodash": "^4.14.168",
     "@types/react": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",

--- a/server/util/urlUtil.ts
+++ b/server/util/urlUtil.ts
@@ -1,14 +1,14 @@
-import { isString, isArray } from 'lodash'
+import TypeChecker from 'share/util/typeChecker'
 
 const getOrElse = (
   queryParam?: string | string[],
   getIfUndefined = (): string => '',
   getIfArray = (arr: string[]): string => arr.join(','),
 ): string => {
-  if (isString(queryParam)) {
+  if (TypeChecker.isString(queryParam)) {
     return queryParam
   }
-  if (isArray(queryParam)) {
+  if (TypeChecker.isArray(queryParam)) {
     return getIfArray(queryParam)
   }
   return getIfUndefined()

--- a/share/util/typeChecker.ts
+++ b/share/util/typeChecker.ts
@@ -1,0 +1,15 @@
+const isArray = Array.isArray
+const isString = (value: any): value is string => typeof value?.valueOf() === 'string'
+const isNumber = (value: any): value is number  => typeof value?.valueOf() === 'number'
+const isFunction = (value: any): value is (...args: any[]) => any => typeof value?.valueOf() === 'function'
+const isBoolean = (value: any): value is boolean => typeof value?.valueOf() === 'boolean'
+
+const TypeChecker = {
+  isArray,
+  isString,
+  isNumber,
+  isFunction,
+  isBoolean
+}
+
+export default TypeChecker


### PR DESCRIPTION
#### 변경 내역
- type check 시 [lodash](https://lodash.com/) library 대신 native code 사용

#### 왜?
- https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore 
- lodash 의 많은 method 들을 native code 를 통해 처리 가능
   - bundle size 를 줄이고, 로직을 명확하게 하기 위해 불필요한 dependency 제거
   